### PR TITLE
make comment column layout optional, disable by default

### DIFF
--- a/M-x.lua
+++ b/M-x.lua
@@ -31,6 +31,7 @@ local opts = {
 
   search_heading = 'M-x',
   filter_by_fields = {'cmd', 'key', 'comment'},
+  column_layout = false,
 }
 
 (require 'mp.options').read_options(opts, mp.get_script_name())
@@ -174,7 +175,13 @@ function em:get_line(_, v)
       a:append(self:get_font_color('comment'))
       a:append(cmd)
       a:append('\\h(' .. key .. ')')
-      a:append(get_spaces(comment_offset - cmdkbd_len))
+
+      if opts.column_layout then
+        a:append(get_spaces(comment_offset - cmdkbd_len))
+      else
+        a:append(' ')
+      end
+
       a:append('(' .. why_inactive .. ')')
       return a.text
     end
@@ -184,7 +191,13 @@ function em:get_line(_, v)
     a:append(self:get_font_color('accent'))
     a:append('\\h(' .. key .. ')')
     a:append(self:get_font_color('comment'))
-    a:append(get_spaces(comment_offset - cmdkbd_len))
+
+    if opts.column_layout then
+      a:append(get_spaces(comment_offset - cmdkbd_len))
+    else
+      a:append(' ')
+    end
+
     a:append(comment and comment or '')
     return a.text
 end

--- a/README.org
+++ b/README.org
@@ -129,6 +129,7 @@ menu_y_padding=2
 
 search_heading=M-x # heading text of a search bar
 filter_by_fields=[ "cmd", "key", "comment" ] # look for explanation below
+column_layout=no
 #+end_src
 
 ~filter_by_fields~ option will determine in which fields to look for your search


### PR DESCRIPTION
On the majority of systems, the comment column layout might not be aligned properly due to incompatible default font, therefore make the column layout optional, and disable it by default.